### PR TITLE
fix: Change market_module import on long term report

### DIFF
--- a/market_module/long_term/report/report_long_term.py
+++ b/market_module/long_term/report/report_long_term.py
@@ -1,4 +1,4 @@
-from market_module.market_module.long_term.plotting_processing_functions.outputs_to_html import output_to_html, output_to_html_no_index, output_to_html_no_index_transpose, output_to_html_list
+from market_module.long_term.plotting_processing_functions.outputs_to_html import output_to_html, output_to_html_no_index, output_to_html_no_index_transpose, output_to_html_list
 from jinja2 import Environment, FileSystemLoader, PackageLoader, select_autoescape
 import os
 


### PR DESCRIPTION
Changing market_module import for report to root of this repository and not from embers_offline.